### PR TITLE
Fix more warnings.

### DIFF
--- a/src/player/CodecsComponent.cpp
+++ b/src/player/CodecsComponent.cpp
@@ -13,7 +13,7 @@
 #include <QResource>
 #include <QSaveFile>
 #include <QStandardPaths>
-#include <QSysInfo>
+#include <QOperatingSystemVersion>
 #include <QCryptographicHash>
 #include <QTemporaryDir>
 
@@ -483,11 +483,12 @@ static void probeCodecs()
 #endif
 
 #ifdef Q_OS_MAC
+  auto current = QOperatingSystemVersion::current();
   // Unsupported, but avoid picking up broken Perian decoders.
-  if (QSysInfo::MacintoshVersion <= QSysInfo::MV_10_10)
+  if (current <= QOperatingSystemVersion::OSXYosemite)
     g_systemAudioDecoderWhitelist.remove("ac3_at");
   // Unknown Apple crashes
-  if (QSysInfo::MacintoshVersion <= QSysInfo::MV_10_11)
+  if (current <= QOperatingSystemVersion::OSXElCapitan)
     g_systemAudioDecoderWhitelist.remove("aac_at");
 #endif
 }

--- a/src/power/PowerComponentWin.cpp
+++ b/src/power/PowerComponentWin.cpp
@@ -1,3 +1,5 @@
+#include <QOperatingSystemVersion>
+
 #include <windows.h>
 
 #include "PowerComponentWin.h"
@@ -40,7 +42,7 @@ bool PowerComponentWin::PowerOff()
 {
   DWORD shutdownFlags = SHUTDOWN_INSTALL_UPDATES | SHUTDOWN_POWEROFF;
 
-  if (QSysInfo::WindowsVersion >= QSysInfo::WV_WINDOWS8)
+  if (QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows8)
     shutdownFlags |= SHUTDOWN_HYBRID;
 
   return InitiateShutdownW(NULL, NULL, 0, shutdownFlags,

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -476,7 +476,7 @@ bool SettingsComponent::loadDescription()
 
   m_sectionIndex = 0;
 
-  for(const QJsonValue& val : doc.array())
+  for(auto val : doc.array())
   {
     if (!val.isObject())
     {
@@ -533,7 +533,7 @@ void SettingsComponent::parseSection(const QJsonObject& sectionObject)
     {
       defaultval = QVariant();
       // Whichever default matches the current platform first is used.
-      for(const auto& v : defaults.toArray())
+      for(auto v : defaults.toArray())
       {
         auto vobj = v.toObject();
         int defPlatformMask = platformMaskFromObject(vobj);
@@ -557,7 +557,7 @@ void SettingsComponent::parseSection(const QJsonObject& sectionObject)
     if (valobj.contains("possible_values") && valobj.value("possible_values").isArray())
     {
       auto list = valobj.value("possible_values").toArray();
-      for(const auto& v : list)
+      for(auto v : list)
       {
         int platform = PLATFORM_ANY;
 
@@ -599,7 +599,7 @@ int SettingsComponent::platformMaskFromObject(const QJsonObject& object)
     // platforms can be both array or a single string
     if (platforms.isArray())
     {
-      for(const QJsonValue& pl : platforms.toArray())
+      for(auto pl : platforms.toArray())
       {
         if (!pl.isString())
           continue;
@@ -617,7 +617,7 @@ int SettingsComponent::platformMaskFromObject(const QJsonObject& object)
     QJsonValue val = object.value("platforms_excluded");
     if (val.isArray())
     {
-      for(const QJsonValue& pl : val.toArray())
+      for(auto pl : val.toArray())
       {
         if (!pl.isString())
           continue;


### PR DESCRIPTION
* Deprecation: `QSysInfo::MacintoshVersion`/`QSysInfo::WindowsVersion` -> `QOperatingSystemVersion::current()`

* `loop variable 'v' is always a copy because the range of type 'QJsonArray' does not return a reference`, see detailed explanation [here](https://stackoverflow.com/a/49979209).

After this it builds without any warnings on macOS with QT 5.15.2 (except some warnings from QtCore 😂).