### PR TITLE
Fix debian dependencies in linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This build strips a lot of un-needed things from the player.
 ## Building at a glance (Linux)
 
 ```bash
-sudo apt install autoconf automake libtool libharfbuzz-dev libfreetype6-dev libfontconfig1-dev libx11-dev libxrandr-dev libvdpau-dev libva-dev mesa-common-dev libegl1-mesa-dev yasm libasound2-dev libpulse-dev libuchardet-dev zlib1g-dev libfribidi-dev git libgnutls28-dev libgl1-mesa-dev libsdl2-dev cmake wget python g++ qtwebengine5-dev qtquickcontrols2-5-dev libqt5x11extras5-dev libcec-dev qml-module-qtwebengine qml-module-qtwebchannel qtbase5-private-dev
+sudo apt install autoconf automake libtool libharfbuzz-dev libfreetype6-dev libfontconfig1-dev libx11-dev libxrandr-dev libvdpau-dev libva-dev mesa-common-dev libegl1-mesa-dev yasm libasound2-dev libpulse-dev libuchardet-dev zlib1g-dev libfribidi-dev git libgnutls28-dev libgl1-mesa-dev libsdl2-dev cmake wget python g++ qtwebengine5-dev qtquickcontrols2-5-dev libqt5x11extras5-dev libcec-dev qml-module-qtquick-controls qml-module-qtwebengine qml-module-qtwebchannel qtbase5-private-dev
 mkdir jmp; cd jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build


### PR DESCRIPTION
Add `qml-module-qtquick-controls` to the `apt install` line