### PR TITLE
Add Back/Forward mouse buttons handler.

### DIFF
--- a/src/ui/EventFilter.cpp
+++ b/src/ui/EventFilter.cpp
@@ -7,6 +7,7 @@
 #include "settings/SettingsComponent.h"
 #include "input/InputKeyboard.h"
 #include "KonvergoWindow.h"
+#include <QQuickItem>
 
 #include <QKeyEvent>
 #include <QObject>
@@ -85,6 +86,22 @@ bool EventFilter::eventFilter(QObject* watched, QEvent* event)
         }
       }
     }
+
+    if (event->type() == QEvent::MouseButtonPress)
+    {
+      QMouseEvent* mouseEvent = dynamic_cast<QMouseEvent*>(event);
+
+      if (mouseEvent) {
+        QQuickItem* webView = window->findChild<QQuickItem*>("web");
+
+        if (mouseEvent->button() == Qt::BackButton)
+          QMetaObject::invokeMethod(webView, "goBack");
+
+        if (mouseEvent->button() == Qt::ForwardButton)
+          QMetaObject::invokeMethod(webView, "goForward");
+      }
+    }
+
     return QObject::eventFilter(watched, event);
   }
 


### PR DESCRIPTION
Fix #41. 
Has one flaw though: if you back to main screen and click "Back" button again history will be forgotten and "Forward" will do nothing. Don't think it's critical.

Another question that i didn't test - TV mode. Don't know what is it and how to get into, but there's [different flow for desktop mode](https://github.com/jellyfin/jellyfin-media-player/blob/7b7f25b6c801c112f6b79c41ed9ce93ae78b92db/src/ui/EventFilter.cpp#L61-L89) so i put code only there.