### PR TITLE
Manually set application name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,8 @@ int main(int argc, char *argv[])
       qputenv("QT_SCALE_FACTOR", scale.toUtf8());
 
     QApplication app(newArgc, newArgv);
+    app.setApplicationName("Jellyfin Media Player");
+
 #if defined(Q_OS_WIN) 
     // Setting window icon on OSX will break user ability to change it
     app.setWindowIcon(QIcon(":/images/icon.png"));


### PR DESCRIPTION
This fixes the application name in the "alt+tab" switcher on GNOME (possibly other desktop environments too) and also in the GNOME top bar (again possibly on other desktop environments too). 

Without this, application appeared as "jellyfinmediaplayer" in the GNOME top bar and in "alt+tab". Now it will appear as "Jellyfin Media Player" as it should.

Decided to do it globally instead of Linux specifically since it couldn't hurt. 