### PR TITLE
Add StartupWMClass to .desktop file

### DIFF
--- a/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
+++ b/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
@@ -6,6 +6,7 @@ Exec=jellyfinmediaplayer
 Icon=com.github.iwalton3.jellyfin-media-player
 Terminal=false
 Type=Application
+StartupWMClass=jellyfinmediaplayer
 Categories=AudioVideo;Video;Player;TV;
 
 Actions=DesktopF;DesktopW;TVF;TVW


### PR DESCRIPTION
This is needed so that desktop environments know which application the window belongs to. For example, without this, GNOME shows the icon in the dock twice when JMP running and it's in your favorites