### PR TITLE
Updated Linux build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Related Documents:
 ## Building at a glance (Linux)
 
 ```bash
-sudo apt install autoconf automake libtool libharfbuzz-dev libfreetype6-dev libfontconfig1-dev libx11-dev libxrandr-dev libvdpau-dev libva-dev mesa-common-dev libegl1-mesa-dev yasm libasound2-dev libpulse-dev libuchardet-dev zlib1g-dev libfribidi-dev git libgnutls28-dev libgl1-mesa-dev libsdl2-dev cmake wget python g++ qtwebengine5-dev qtquickcontrols2-5-dev libqt5x11extras5-dev libcec-dev qml-module-qtquick-controls qml-module-qtwebengine qml-module-qtwebchannel qtbase5-private-dev
+sudo apt install build-essential autoconf automake libtool libharfbuzz-dev libfreetype6-dev libfontconfig1-dev libx11-dev libxrandr-dev libvdpau-dev libva-dev mesa-common-dev libegl1-mesa-dev yasm libasound2-dev libpulse-dev libuchardet-dev zlib1g-dev libfribidi-dev git libgnutls28-dev libgl1-mesa-dev libsdl2-dev cmake wget python g++ qtwebengine5-dev qtquickcontrols2-5-dev libqt5x11extras5-dev libcec-dev qml-module-qtquick-controls qml-module-qtwebengine qml-module-qtwebchannel qtbase5-private-dev curl unzip
 mkdir jmp; cd jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build
@@ -28,7 +28,7 @@ echo --disable-cplayer >> mpv_options
 sudo ./install
 sudo ldconfig
 cd ~/jmp/
-git clone git://github.com/iwalton3/jellyfin-media-player
+git clone git://github.com/jellyfin/jellyfin-media-player
 cd jellyfin-media-player
 ./download_webclient.sh
 cd build


### PR DESCRIPTION
- wrong jellyfin-media-player repo URL
- missing build-essential dependency which fails mpv build
- missing curl and unzip dependencies which fail ./download_webclient.sh