### PR TITLE
Added Quit App functionality

### DIFF
--- a/native/nativeshell.js
+++ b/native/nativeshell.js
@@ -8,6 +8,7 @@ const features = [
     "externallinks",
     "clientsettings",
     "multiserver",
+    "quitapp",
     "remotecontrol",
     "fullscreenchange",
     "filedownload",
@@ -53,6 +54,10 @@ window.NativeShell = {
 
     openClientSettings() {
         showSettingsModal();
+    },
+
+    quitApp() {
+        window.api.system.exit();
     },
 
     getPlugins() {


### PR DESCRIPTION
This is the JMP side of my PR to the Jellyfin Web project: https://github.com/jellyfin/jellyfin-web/pull/3318

I'm using the Jellyfin Media Player in TV mode as a full screen app (open via Flex Launcher) and needed a way to close the program via the keyboard navigation. To resolve this I've added a Quit Application link below the Sign Out menu item.

Unfortunately I haven't been able to test this in the JMP yet so requires testing but the menu item exists in the menu and is hidden using the appHost.supports() function as per the other web menu items. I'm not sure if further conditional checks to determine if this should appear (eg if its an embedded or iOS/Android app the Quit Application link should not appear) need to happen in the Web project or if that is determined here in the player.

I can see that there was an existing function for the system component to exit the application so I have tried to reuse this. I'm also not sure if it should be a function that requires a user confirmation (eg Are you sure you want to exit?).

Is this something that the Jellyfin Community would consider adding to the application?