### PR TITLE
Added ~/ to early jmp directory instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Related Documents:
 
 ```bash
 sudo apt install build-essential autoconf automake libtool libharfbuzz-dev libfreetype6-dev libfontconfig1-dev libx11-dev libxrandr-dev libvdpau-dev libva-dev mesa-common-dev libegl1-mesa-dev yasm libasound2-dev libpulse-dev libuchardet-dev zlib1g-dev libfribidi-dev git libgnutls28-dev libgl1-mesa-dev libsdl2-dev cmake wget python g++ qtwebengine5-dev qtquickcontrols2-5-dev libqt5x11extras5-dev libcec-dev qml-module-qtquick-controls qml-module-qtwebengine qml-module-qtwebchannel qtbase5-private-dev curl unzip
-mkdir jmp; cd jmp
+mkdir ~/jmp; cd ~/jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build
 echo --enable-libmpv-shared > mpv_options


### PR DESCRIPTION
In case the user is in a different directory their jmp directory might not get created in users home folder. It's not a big thing, but now it should be possible to just copy paste without ending up in the wrong directory later.