### PR TITLE
Update git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ echo --disable-cplayer >> mpv_options
 sudo ./install
 sudo ldconfig
 cd ~/jmp/
-git clone git://github.com/jellyfin/jellyfin-media-player
+git clone https://github.com/jellyfin/jellyfin-media-player.git
 cd jellyfin-media-player
 ./download_webclient.sh
 cd build


### PR DESCRIPTION
GitHub no longer allows the `git://` protocol.

Fixes this error:

```
$ git clone git://github.com/jellyfin/jellyfin-media-player
Cloning into 'jellyfin-media-player'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
