### PR TITLE
Add build for Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        tag: [focal, hirsute, impish]
+        tag: [focal, hirsute, impish, jammy]
     runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Github actions build for Ubuntu 22.04.

fix for #255 

Tested the GA on my fork and the build works:

https://github.com/macr/jellyfin-media-player/actions/runs/2437282571#artifacts
