### PR TITLE
Allow screensaver when video is paused.

### DIFF
--- a/native/mpvVideoPlayer.js
+++ b/native/mpvVideoPlayer.js
@@ -659,6 +659,7 @@
 
     unpause() {
         window.api.player.play();
+        window.api.power.setScreensaverEnabled(false);
     }
 
     paused() {

--- a/native/mpvVideoPlayer.js
+++ b/native/mpvVideoPlayer.js
@@ -648,6 +648,7 @@
 
     pause() {
         window.api.player.pause();
+        window.api.power.setScreensaverEnabled(true);
     }
 
     // This is a retry after error


### PR DESCRIPTION
Update mpvVideoPlayer.js. Wasn't sure if it would be more ideal in the pause function which pauses the player, or the onPause event. Opted for the function.

Related to #141.

This is more ideal, especially in a desktop scenario where I might leave a video open after finishing it (but paused) before going to sleep.