### PR TITLE
Add support for DVBSUB subtitles

### DIFF
--- a/native/nativeshell.js
+++ b/native/nativeshell.js
@@ -96,6 +96,7 @@ function getDeviceProfile() {
             {'Format': 'smi', 'Method': 'External'},
             {'Format': 'pgssub', 'Method': 'Embed'},
             {'Format': 'dvdsub', 'Method': 'Embed'},
+            {'Format': 'dvbsub', 'Method': 'Embed'},
             {'Format': 'pgs', 'Method': 'Embed'}
         ]
     };


### PR DESCRIPTION
Fix #277 .

Without this PR, video files with DVBSUB subtitles require transcoding although MPV supports the subtitle format. With this fix, Jellyfin Media Player can direct play such files (unless video codec forces transcoding, of course).