### PR TITLE
Add input map for DualShock 4 connected via USB

### DIFF
--- a/resources/inputmaps/dualshock4-usb.json
+++ b/resources/inputmaps/dualshock4-usb.json
@@ -1,0 +1,65 @@
+{
+  "name": "Playstation DualShock 4 - USB",
+  "idmatcher": "PS4 Controller",
+  "mapping": {
+    // D-Pad
+    "KEY_BUTTON_12": "down",
+    "KEY_BUTTON_11": "up",
+    "KEY_BUTTON_14": "right",
+    "KEY_BUTTON_13": "left",
+
+    // Square
+    "KEY_BUTTON_2": "cycle_audio",
+
+    // X
+    "KEY_BUTTON_0": "enter",
+
+    // Circle
+    "KEY_BUTTON_1": {
+      "short": "back",
+      "long": "home"
+    },
+
+    // Triangle
+    "KEY_BUTTON_3": "cycle_subtitles",
+
+    // L1
+    "KEY_BUTTON_9": "seek_backward",
+
+    // L2
+    "KEY_AXIS_4_DOWN": "seek_forward",
+
+    // option
+    "KEY_BUTTON_6": "host:toggleDebug",
+
+    // start
+    "KEY_BUTTON_4": "host:fullscreen",
+
+    // press left thumbstick
+    "KEY_BUTTON_7": "",
+
+    // press right thumbstick
+    "KEY_BUTTON_8": "",
+
+    // Playstation button
+    "KEY_BUTTON_5": {
+      "short": "home",
+      "long": "exit"
+    },
+
+    // Trackpad press
+    "KEY_BUTTON_15": "search",
+
+    // left thumbstick axis
+    "KEY_AXIS_0_UP": "left",
+    "KEY_AXIS_0_DOWN": "right",
+    "KEY_AXIS_1_UP": "up",
+    "KEY_AXIS_1_DOWN": "down",
+
+    // right thumbstick axis
+    "KEY_AXIS_3_UP": "increase_volume",
+    "KEY_AXIS_3_DOWN": "decrease_volume",
+    "KEY_AXIS_2_UP": "decrease_audio_delay",
+    "KEY_AXIS_2_DOWN": "increase_audio_delay"
+  }
+}


### PR DESCRIPTION
Based on already-existing inputmap for DS4. Only corresponding key names are adjusted to match with USB connection.