### PR TITLE
Add Default Playback Speed settings

### DIFF
--- a/native/mpvVideoPlayer.js
+++ b/native/mpvVideoPlayer.js
@@ -108,7 +108,7 @@
             /**
              * @type {float}
              */
-            this._playRate = 1;
+            this._playRate;
             /**
              * @type {boolean}
              */
@@ -678,6 +678,15 @@
     }
 
     getPlaybackRate() {
+        if(!this._playRate) //On startup grab default
+        {
+            let playRate = window.jmpInfo.settings.video.default_playback_speed;
+
+            if(!playRate) //fallback if default missing
+                playRate = 1;
+
+            this._playRate = playRate;
+        }
         return this._playRate;
     }
 

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -383,6 +383,19 @@
           [ "noscaling", "video.aspect.noscale" ],
           [ "custom", "video.aspect.custom" ]
         ]
+      },
+      {
+        "value": "default_playback_speed",
+        "default": 1.0,
+        "possible_values": [
+          [ 0.5, "0.5x" ],
+          [ 0.75, "0.75x" ],
+          [ 1.0, "1x" ],
+          [ 1.25, "1.25x" ],
+          [ 1.5, "1.5x" ],
+          [ 1.75, "1.75x" ],
+          [ 2.0, "2x" ]
+        ]
       }
     ]
   },


### PR DESCRIPTION
Allow a default playback rate to be set for the video player, which defaults to 1.

This is an enhancement for people like me who watch things at 1.5x most of the time. Related to https://github.com/jellyfin/jellyfin-media-player/pull/434