### PR TITLE
qt6: fixed build errors & warnings

### DIFF
--- a/src/input/InputComponent.cpp
+++ b/src/input/InputComponent.cpp
@@ -132,7 +132,7 @@ void InputComponent::handleAction(const QString& action)
         else
         {
           qDebug() << "Invoking slot" << qPrintable(recvSlot->m_slot.data());
-          QGenericArgument arg0 = QGenericArgument();
+          auto arg0 = QMetaMethodArgument();
 
           if (recvSlot->m_hasArguments)
             arg0 = Q_ARG(const QString&, hostArguments);
@@ -186,14 +186,14 @@ void InputComponent::remapInput(const QString &source, const QString &keycode, I
   m_autoRepeatActions.clear();
 
   auto actions = m_mappings->mapToAction(source, keycode);
-  for (auto action : actions)
+  for (const auto& action : actions)
   {
-    if (action.type() == QVariant::String)
+    if (action.typeId() == QMetaType::QString)
     {
       queuedActions.append(action.toString());
       m_autoRepeatActions.append(action.toString());
     }
-    else if (action.type() == QVariant::Map)
+    else if (action.typeId() == QMetaType::QVariantMap)
     {
       QVariantMap map = action.toMap();
       if (map.contains("long"))
@@ -211,7 +211,7 @@ void InputComponent::remapInput(const QString &source, const QString &keycode, I
         queuedActions.append(map.value("short").toString());
       }
     }
-    else if (action.type() == QVariant::List)
+    else if (action.typeId() == QMetaType::QStringList)
     {
       queuedActions.append(action.toStringList());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ void ShowLicenseInfo()
   QFile licenses(":/misc/licenses.txt");
   licenses.open(QIODevice::ReadOnly | QIODevice::Text);
   QByteArray contents = licenses.readAll();
-  printf("%.*s\n", contents.size(), contents.data());
+  printf("%.*s\n", static_cast<int>(contents.size()), contents.data());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -160,9 +160,15 @@ int main(int argc, char *argv[])
 
     auto scale = parser.value("scale-factor");
     if (scale.isEmpty() || scale == "auto")
+    {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
       QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+    }
     else if (scale != "none")
+    {
       qputenv("QT_SCALE_FACTOR", scale.toUtf8());
+    }
 
     auto platform = parser.value("platform");
     if (!(platform.isEmpty() || platform == "default"))

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -519,6 +519,10 @@ void PlayerComponent::handleMpvEvent(mpv_event *event)
           m_playbackCanceled = true;
           break;
         }
+        case MPV_END_FILE_REASON_EOF:
+        case MPV_END_FILE_REASON_QUIT:
+        case MPV_END_FILE_REASON_REDIRECT:
+          break;
       }
 
       if (!m_streamSwitchImminent)
@@ -948,7 +952,7 @@ void PlayerComponent::setPlaybackRate(int rate)
 qint64 PlayerComponent::getPosition()
 {
   QVariant time = mpv::qt::get_property(m_mpv, "playback-time");
-  if (time.canConvert(QMetaType::Double))
+  if (time.canConvert<double>())
     return time.toDouble();
   return 0;
 }
@@ -957,7 +961,7 @@ qint64 PlayerComponent::getPosition()
 qint64 PlayerComponent::getDuration()
 {
   QVariant time = mpv::qt::get_property(m_mpv, "duration");
-  if (time.canConvert(QMetaType::Double))
+  if (time.canConvert<double>())
     return time.toDouble();
   return 0;
 }
@@ -1001,7 +1005,7 @@ void PlayerComponent::updateAudioDeviceList()
   QSet<QString> devices;
   for(const QVariant& d : list.toList())
   {
-    Q_ASSERT(d.type() == QVariant::Map);
+    Q_ASSERT(d.typeId() == QMetaType::QVariantMap);
     QVariantMap dmap = d.toMap();
 
     QString device = dmap["name"].toString();

--- a/src/player/QtHelper.h
+++ b/src/player/QtHelper.h
@@ -136,11 +136,7 @@ private:
         return r;
     }
     bool test_type(const QVariant &v, QMetaType::Type t) {
-        // The Qt docs say: "Although this function is declared as returning
-        // "QVariant::Type(obsolete), the return value should be interpreted
-        // as QMetaType::Type."
-        // So a cast really seems to be needed to avoid warnings (urgh).
-        return static_cast<int>(v.type()) == static_cast<int>(t);
+        return v.typeId() == t;
     }
     void set(mpv_node *dst, const QVariant &src) {
         if (test_type(src, QMetaType::QString)) {

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -53,12 +53,12 @@ void SettingsComponent::cycleSettingCommand(const QString& args)
   // If no possible values are defined, check the type of the default value.
   // In the case it's a boolean simply negate the current value to cycle through.
   // Otherwise log an error message, that it's not possible to cycle through the value.
-  if (values.size() == 0)
+  if (values.empty())
   {
-    if (section->defaultValue(valueName).type() == QVariant::Bool)
+    if (section->defaultValue(valueName).typeId()== QMetaType::Bool)
     {
       QVariant currentValue = section->value(valueName);
-      auto nextValue = currentValue.toBool() ? false : true;
+      auto nextValue = !currentValue.toBool();
       setValue(sectionID, valueName, nextValue);
       qDebug() << "Setting" << settingName << "to " << (nextValue ? "Enabled" : "Disabled");
       emit SystemComponent::Get().settingsMessage(valueName, nextValue ? "Enabled" : "Disabled");
@@ -366,7 +366,7 @@ void SettingsComponent::setValues(const QVariantMap& options)
   QString key = options["key"].toString();
   QVariant values = options["value"];
 
-  if (values.type() == QVariant::Map || values.isNull())
+  if (values.typeId() == QMetaType::QVariantMap || values.isNull())
   {
     SettingsSection* section = getSection(key);
     if (!section)
@@ -385,7 +385,7 @@ void SettingsComponent::setValues(const QVariantMap& options)
 
     saveSection(section);
   }
-  else if (values.type() == QVariant::String)
+  else if (values.typeId() == QMetaType::QString)
   {
     setValue(SETTINGS_SECTION_WEBCLIENT, key, values);
   }

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -116,10 +116,9 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   connect(&PlayerComponent::Get(), &PlayerComponent::windowVisible,
           this, &KonvergoWindow::playerWindowVisible, Qt::QueuedConnection);
 
-  // this is using old syntax because ... reasons. QQuickCloseEvent is not public class
-  connect(this, SIGNAL(closing(QQuickCloseEvent*)), this, SLOT(closingWindow()));
+  connect(this, &KonvergoWindow::closing, this, &KonvergoWindow::closingWindow);
 
-  connect(qApp, &QCoreApplication::aboutToQuit, this, &KonvergoWindow::closingWindow);
+  connect(qApp, &QCoreApplication::aboutToQuit, this, &KonvergoWindow::saveGeometry);
 
 #ifdef Q_OS_MAC
   m_osxPresentationOptions = 0;
@@ -145,6 +144,7 @@ void KonvergoWindow::closingWindow()
   if (!SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "fullscreen").toBool())
     saveGeometry();
 
+  qDebug() << "Quitting application...";
   qApp->quit();
 }
 

--- a/src/utils/CachedRegexMatcher.cpp
+++ b/src/utils/CachedRegexMatcher.cpp
@@ -48,7 +48,7 @@ QVariantList CachedRegexMatcher::match(const QString& input)
       // found match
       QVariant returnValue = matcher.second;
 
-      if (re.captureCount() > 0 && matcher.second.type() == QVariant::String)
+      if (re.captureCount() > 0 && matcher.second.typeId() == QMetaType::QString)
       {
         QString value(matcher.second.toString());
 


### PR DESCRIPTION
The qt6 branch didn't build for me (on Arch Linux, Qt `6.5.1`), so I fixed the errors and warnings:

* Mostly QVariant to QMetaType conversions, because some stuff from QVariant is deprecated: https://doc.qt.io/qt-6/qvariant-obsolete.html
* Some clang-tidy stuff I came across
* Some other errors