### PR TITLE
fix: skipintro plugin client freeze

### DIFF
--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -84,6 +84,13 @@ class skipIntroPlugin {
                 });
             }
 
+            function handleClick(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                skipIntro();
+                document.querySelector('.skipIntro .btnSkipIntro').removeEventListener('click', handleClick, { useCapture: true });
+            }
+
             async function injectSkipIntroHtml() {
                 const playerContainer = await waitForElement('.upNextContainer', 5000);
                 // inject only if it doesn't exist
@@ -91,11 +98,7 @@ class skipIntroPlugin {
                     playerContainer.insertAdjacentHTML('afterend', skipIntroHtml);
                 }
 
-                document.querySelector('.skipIntro .btnSkipIntro').addEventListener('click', (e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    skipIntro();
-                }, { useCapture: true });
+                document.querySelector('.skipIntro .btnSkipIntro').addEventListener('click', handleClick, { useCapture: true });
 
                 if (window.PointerEvent) {
                     document.querySelector('.skipIntro .btnSkipIntro').addEventListener('pointerdown', (e) => {


### PR DESCRIPTION
Fixes #405

The skip intro button click handler is triggered multiples times after pressing the skip intro button, causing a client freeze.

Tested on Win11.