### PR TITLE
Add qt6 packages needed for QT6 build on ubuntu 23.04 to README.md, fix build of qt6 on Ubuntu 23.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Related Documents:
 ## Building at a glance (Linux)
 
 ```bash
-sudo apt install build-essential autoconf automake libtool libharfbuzz-dev libfreetype6-dev libfontconfig1-dev libx11-dev libxrandr-dev libvdpau-dev libva-dev mesa-common-dev libegl1-mesa-dev yasm libasound2-dev libpulse-dev libuchardet-dev zlib1g-dev libfribidi-dev git libgnutls28-dev libgl1-mesa-dev libsdl2-dev cmake wget python g++ qtwebengine5-dev qtquickcontrols2-5-dev libqt5x11extras5-dev libcec-dev qml-module-qtquick-controls qml-module-qtwebengine qml-module-qtwebchannel qtbase5-private-dev curl unzip
+sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev python qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
 mkdir ~/jmp; cd ~/jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build
 echo -Dlibmpv=true > mpv_options
 echo -Dpipewire=disabled >> mpv_options # hopefully temporary
-./rebuild -j4
+./rebuild -j`nproc`
 sudo ./install
 sudo ln -s /usr/local/lib/x86_64-linux-gnu/libmpv.so /usr/local/lib/x86_64-linux-gnu/libmpv.so.1
 sudo ln -sf /usr/local/lib/x86_64-linux-gnu/libmpv.so /usr/local/lib/libmpv.so.2
@@ -35,7 +35,7 @@ cd jellyfin-media-player
 ./download_webclient.sh
 cd build
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local/ ..
-make -j4
+make -j`nproc`
 sudo make install
 rm -rf ~/jmp/
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Related Documents:
 ## Building at a glance (Linux)
 
 ```bash
-sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev meson python3 qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
+sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev meson python3 qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebengine-controlsdelegates qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-5compat-dev qt6-base-private-dev qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
 mkdir ~/jmp; cd ~/jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Related Documents:
 ## Building at a glance (Linux)
 
 ```bash
-sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev python3 qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
+sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev meson python3 qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
 mkdir ~/jmp; cd ~/jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Related Documents:
 ## Building at a glance (Linux)
 
 ```bash
-sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev python qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
+sudo apt install  autoconf automake build-essential cmake curl g++ git libasound2-dev libcec-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libgl1-mesa-dev libgnutls28-dev libharfbuzz-dev libpulse-dev libqt5x11extras5-dev libsdl2-dev libtool libuchardet-dev libva-dev libvdpau-dev libx11-dev libxrandr-dev mesa-common-dev python3 qml6-module-qtqml-workerscript qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-window qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtwebview qml-module-qtquick-controls qml-module-qtwebchannel qml-module-qtwebengine qt6-webengine-private-dev qtbase5-private-dev qtquickcontrols2-5-dev qtwebengine5-dev unzip wget yasm zlib1g-dev
 mkdir ~/jmp; cd ~/jmp
 git clone https://github.com/mpv-player/mpv-build.git
 cd mpv-build

--- a/src/input/InputComponent.cpp
+++ b/src/input/InputComponent.cpp
@@ -132,7 +132,7 @@ void InputComponent::handleAction(const QString& action)
         else
         {
           qDebug() << "Invoking slot" << qPrintable(recvSlot->m_slot.data());
-          auto arg0 = QMetaMethodArgument();
+          QGenericArgument arg0 = QGenericArgument();
 
           if (recvSlot->m_hasArguments)
             arg0 = Q_ARG(const QString&, hostArguments);

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -116,7 +116,8 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   connect(&PlayerComponent::Get(), &PlayerComponent::windowVisible,
           this, &KonvergoWindow::playerWindowVisible, Qt::QueuedConnection);
 
-  connect(this, &KonvergoWindow::closing, this, &KonvergoWindow::closingWindow);
+  // this is using old syntax because ... reasons. QQuickCloseEvent is not public class
+  connect(this, SIGNAL(closing(QQuickCloseEvent*)), this, SLOT(closingWindow()));
 
   connect(qApp, &QCoreApplication::aboutToQuit, this, &KonvergoWindow::saveGeometry);
 


### PR DESCRIPTION
- This updates the Readme to add packages I needed to build the qt6 fork on Ubuntu 23.04. This may not be an exhaustive list of needed packages. I didn't remove any of the qt5 packages in the list, and also sorted the list of packages needed.
- Also reverted some changes from https://github.com/jellyfin/jellyfin-media-player/pull/455 / https://github.com/jellyfin/jellyfin-media-player/commit/2890687f66b8804eb1d8075b5a66d6967e7631bb which were breaking my build on Ubuntu 23.04.
- Build with these steps  was tested in a `ubuntu:23.04` docker container started with `docker run --rm -it ubuntu:23.04`
  - These steps were changed: 
  - `apt update &7 apt install sudo` was run first.
  - modified steps to build jellyfin-media-player from my patch branch, i.e.,
```
cd ~/jmp
git clone https://github.com/satmandu/jellyfin-media-player
cd jellyfin-media-player/
git checkout patch-1
```

![image](https://github.com/jellyfin/jellyfin-media-player/assets/1096701/24001d97-9e32-41eb-8ef4-5afd70ee2307)
