### PR TITLE
Fix window switching monitor when exiting fullscreen

### DIFF
--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -226,6 +226,9 @@ QRect KonvergoWindow::loadGeometry()
   }
   else
   {
+    if (myScreen)
+      nsize = myScreen->geometry();
+
     setGeometry(nsize);
     if (SettingsComponent::Get().value(SETTINGS_SECTION_STATE, "maximized").toBool())
       setVisibility(QWindow::Maximized);


### PR DESCRIPTION
Fixes: #245 

Fixed the issue for me. Tested it for a few months. Had this issue happen constantly before, and since applying these changes, it hasn't happened once.

Tested on Arch Linux, using the jellyfin-media-player AUR package modified to use this branch.

Based on the surrounding code, I don't know if these changes need to be limited to Linux, or if it will work fine for MacOS/Windows as well.