### PR TITLE
Fix window restoring on opening with Hyprland

### DIFF
--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -179,16 +179,12 @@ void KonvergoWindow::saveGeometry()
 
   qDebug() << "Saving window geometry:" << rc;
 
-  if (visibility() == QWindow::Maximized)
-  {
-    SettingsComponent::Get().setValue(SETTINGS_SECTION_STATE, "maximized", true);
-  }
-  else if (visibility() != QWindow::Hidden)
+  if (visibility() != QWindow::Hidden)
   {
     QVariantMap map = {{"x", rc.x()}, {"y", rc.y()},
                        {"width", rc.width()}, {"height", rc.height()}};
     SettingsComponent::Get().setValue(SETTINGS_SECTION_STATE, "geometry", map);
-    SettingsComponent::Get().setValue(SETTINGS_SECTION_STATE, "maximized", false);
+    SettingsComponent::Get().setValue(SETTINGS_SECTION_STATE, "maximized", visibility() == QWindow::Maximized);
   }
   QScreen *curScreen = screen();
   SettingsComponent::Get().setValue(SETTINGS_SECTION_STATE, "lastUsedScreen", curScreen ? curScreen->name() : "");
@@ -226,9 +222,6 @@ QRect KonvergoWindow::loadGeometry()
   }
   else
   {
-    if (myScreen)
-      nsize = myScreen->geometry();
-
     setGeometry(nsize);
     if (SettingsComponent::Get().value(SETTINGS_SECTION_STATE, "maximized").toBool())
       setVisibility(QWindow::Maximized);


### PR DESCRIPTION
Follow-up PR for #478.

@zjeffer reported that #478 broke JMP on Hyprland, a Wayland tiling window manager. This PR is an attempt to fix this, and make sure #245 remains fixed.

In the previous PR, #245 was fixed by using the previous screen geometry rather than the previously saved window geometry when restoring the window geometry. The screen geometry would always be the full width/height of that monitor, e.g. 1920x1080.

In this PR, that change is reverted, so it will restore the previously saved geometry again.
In addition, it will now save the window geometry, regardless of whether the window is maximized or not.
Previously, the window geometry would not be saved if the window was maximized. It would just save that the window was maximized or not  (not saving what monitor the window was on). This was the reason JMP would show up on a different monitor when exiting fullscreen.

For Hyprland specifically, I was able to see a similar issue as @zjeffer reported. For me, Waybar never appeared on top of JMP though, with the standard config for both Hyprland and Waybar.
I was not able to figure out the exact reason/conditions for problems with JMP on Hyprland, but I had success in reproducing the reported issue if the previous monitor was the most left one, and the window matched the full width/height. When that happened, it appeared as if Hyprland didn't attempt to resize the window. Maybe Hyprland thinks that it's meant to be fullscreen, and then doesn't try to resize? I'm not sure.
But some combination of the height, width, x and y of the window appeared to matter.

@zjeffer would you be able to test if this PR fixes the issue on Hyprland for you?