### PR TITLE
Ensure that volume is always a Number

### DIFF
--- a/native/mpvVideoPlayer.js
+++ b/native/mpvVideoPlayer.js
@@ -722,12 +722,15 @@
     }
 
     setVolume(val, save = true) {
-        this._volume = val;
-        if (save) {
-            this.saveVolume((val || 100) / 100);
-            this.events.trigger(this, 'volumechange');
+        val = Number(val);
+        if (!isNaN(val)) {
+            this._volume = val;
+            if (save) {
+                this.saveVolume(val / 100);
+                this.events.trigger(this, 'volumechange');
+            }
+            window.api.player.setVolume(val);
         }
-        window.api.player.setVolume(val);
     }
 
     getVolume() {


### PR DESCRIPTION
This fixes the issue where the volume is set to the maximum volume when setting a random volume by clicking the slider and then invoking the volume up action. The reason for this is that the slider apparently sets the volume to a string '100' instead of a number, and in turn the volume up concatenates the current volume with 2 instead of adding 2. As a result, the volume is set to 100 (minimum of `__2` and `100`) instead of the expected volume. This doesn't apply to the volume down action because `string - number = number`. Obviously…

Forcing the saved volume to always be a number resolves this issue. Additionally, we also don't allow setting the volume to any falsy/undefined value anymore.