### PR TITLE
feat: Improve customization for subtitles

### DIFF
--- a/for-web-developers.md
+++ b/for-web-developers.md
@@ -203,6 +203,10 @@ Current Settings:
          - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/master/resources/settings/settings_description.json#L421-L427)
      - `border_color: string enum`: Controls font border colors of subtitles. Default: `#000000`
          - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/master/resources/settings/settings_description.json#L434-L440)
+     - `background_color: string enum`: Controls backgroud colors of subtitles. Default: `#CCCCCC`
+         - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/master/resources/settings/settings_description.json#L447-L453)
+     - `background_transparency: string enum`: Controls backgroud transparency (in hex) of subtitles. Default: `00`
+         - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/master/resources/settings/settings_description.json#L460-L464)
      - `size: int`: Controls subtitle size. Default is `32`.
          - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/7d5943becc1ca672d599887cac9107836c38d337/resources/settings/settings_description.json#L376-L382)
 

--- a/for-web-developers.md
+++ b/for-web-developers.md
@@ -199,8 +199,10 @@ Current Settings:
  - Subtitle Section (`subtitles`):
      - `placement: string enum`: Controls where subtitles are displayed on the screen. Default: `center,bottom`
          - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/7d5943becc1ca672d599887cac9107836c38d337/resources/settings/settings_description.json#L352-L359)
-     - `color: string enum`: Controls colors of subtitles. Default: `#EEEEEE,#000000`
-         - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/7d5943becc1ca672d599887cac9107836c38d337/resources/settings/settings_description.json#L364-L371)
+     - `color: string enum`: Controls colors of subtitles. Default: `#EEEEEE`
+         - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/master/resources/settings/settings_description.json#L421-L427)
+     - `border_color: string enum`: Controls font border colors of subtitles. Default: `#000000`
+         - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/master/resources/settings/settings_description.json#L434-L440)
      - `size: int`: Controls subtitle size. Default is `32`.
          - Provided options: [see enum](https://github.com/jellyfin/jellyfin-media-player/blob/7d5943becc1ca672d599887cac9107836c38d337/resources/settings/settings_description.json#L376-L382)
 

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -457,11 +457,11 @@
         "value": "background_transparency",
         "default": "00",
         "possible_values": [
-          [ "FF", "0%" ],
-          [ "C0", "25%" ],
-          [ "80", "50%" ],
-          [ "40", "75%" ],
-          [ "00", "100%" ]
+          [ "FF", "subtitles.0%" ],
+          [ "C0", "subtitles.25%" ],
+          [ "80", "subtitles.50%" ],
+          [ "40", "subtitles.75%" ],
+          [ "00", "subtitles.100%" ]
         ]
       },
       {

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -441,6 +441,30 @@
         ]
       },
       {
+        "value": "background_color",
+        "default": "#CCCCCC",
+        "possible_values": [
+          [ "#000000", "subtitles.black" ],
+          [ "#FFFFFF", "subtitles.white" ],
+          [ "#EEEEEE", "subtitles.lightGrey" ],
+          [ "#CCCCCC", "subtitles.blendedLightGrey" ],
+          [ "#FBF93E", "subtitles.yellow" ],
+          [ "#FFFFCC", "subtitles.lightYellow" ],
+          [ "#EEEDB8", "subtitles.blendedLightYellow" ]
+        ]
+      },
+      {
+        "value": "background_transparency",
+        "default": "00",
+        "possible_values": [
+          [ "FF", "0%" ],
+          [ "C0", "25%" ],
+          [ "80", "50%" ],
+          [ "40", "75%" ],
+          [ "00", "100%" ]
+        ]
+      },
+      {
         "value": "size",
         "default": 32,
         "possible_values": [

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -474,6 +474,19 @@
           [ 42, "subtitles.large" ],
           [ 60, "subtitles.huge" ]
         ]
+      },
+      {
+        "value": "font",
+        "default": "sans-serif",
+        "possible_values": [
+          [ "serif", "serif" ],
+          [ "sans-serif", "sans-serif" ],
+          [ "script", "script" ],
+          [ "monospace", "monospace" ],
+          [ "display", "display" ],
+          [ "cursive", "cursive" ],
+          [ "fantasy", "fantasy" ]
+        ]
       }
     ]
   },

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -416,14 +416,28 @@
       },
       {
         "value": "color",
-        "default": "#EEEEEE,#000000",
+        "default": "#EEEEEE",
         "possible_values": [
-          [ "#EEEEEE,#000000", "subtitles.lightGrey" ],
-          [ "#CCCCCC,#000000", "subtitles.blendedLightGrey" ],
-          [ "#FBF93E,#000000", "subtitles.yellow" ],
-          [ "#FFFFCC,#000000", "subtitles.lightYellow" ],
-          [ "#EEEDB8,#000000", "subtitles.blendedLightYellow" ],
-          [ "#FFFFFF,#000000", "subtitles.blackWhite" ]
+          [ "#000000", "subtitles.black" ],
+          [ "#FFFFFF", "subtitles.white" ],
+          [ "#EEEEEE", "subtitles.lightGrey" ],
+          [ "#CCCCCC", "subtitles.blendedLightGrey" ],
+          [ "#FBF93E", "subtitles.yellow" ],
+          [ "#FFFFCC", "subtitles.lightYellow" ],
+          [ "#EEEDB8", "subtitles.blendedLightYellow" ]
+        ]
+      },
+      {
+        "value": "border_color",
+        "default": "#000000",
+        "possible_values": [
+          [ "#000000", "subtitles.black" ],
+          [ "#FFFFFF", "subtitles.white" ],
+          [ "#EEEEEE", "subtitles.lightGrey" ],
+          [ "#CCCCCC", "subtitles.blendedLightGrey" ],
+          [ "#FBF93E", "subtitles.yellow" ],
+          [ "#FFFFCC", "subtitles.lightYellow" ],
+          [ "#EEEDB8", "subtitles.blendedLightYellow" ]
         ]
       },
       {

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -1157,6 +1157,15 @@ void PlayerComponent::updateSubtitleSettings()
     mpv::qt::set_property(m_mpv, "sub-border-color", borderColor);
   }
 
+  QString backgroundColor = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "background_color").toString();
+  QString backgroundTransparency = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "background_transparency").toString();
+  if (!backgroundColor.isEmpty() && !backgroundTransparency.isEmpty())
+  {
+    // Color is #RRGGBB or #AARRGGBB, insert Alpha after # (at position 1)
+    backgroundColor.insert(1, backgroundTransparency);
+    mpv::qt::set_property(m_mpv, "sub-back-color", backgroundColor);
+  }
+
   QVariant subposString = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "placement");
   auto subpos = subposString.toString().split(",");
   if (subpos.length() == 2)

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -1145,6 +1145,12 @@ void PlayerComponent::updateSubtitleSettings()
   QVariant size = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "size");
   mpv::qt::set_property(m_mpv, "sub-scale", size.toInt() / 32.0);
 
+  QString font = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "font").toString();
+  if (!font.isEmpty())
+  {
+    mpv::qt::set_property(m_mpv, "sub-font", font);
+  }
+
   QString color = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "color").toString();
   if (!color.isEmpty())
   {

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -1145,12 +1145,16 @@ void PlayerComponent::updateSubtitleSettings()
   QVariant size = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "size");
   mpv::qt::set_property(m_mpv, "sub-scale", size.toInt() / 32.0);
 
-  QVariant colorsString = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "color");
-  auto colors = colorsString.toString().split(",");
-  if (colors.length() == 2)
+  QString color = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "color").toString();
+  if (!color.isEmpty())
   {
-    mpv::qt::set_property(m_mpv, "sub-color", colors[0]);
-    mpv::qt::set_property(m_mpv, "sub-border-color", colors[1]);
+    mpv::qt::set_property(m_mpv, "sub-color", color);
+  }
+
+  QString borderColor = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "border_color").toString();
+  if (!borderColor.isEmpty())
+  {
+    mpv::qt::set_property(m_mpv, "sub-border-color", borderColor);
   }
 
   QVariant subposString = SettingsComponent::Get().value(SETTINGS_SECTION_SUBTITLES, "placement");


### PR DESCRIPTION
Improves support for subtitle customization.
Creates new subtitle specific settings that enable: separate font and border color, background color and transparency.

Specifically modifies "subtitles" section of settings:
- placement - unchanged
- color - now sets only font color
- border_color - sets color of font border (previously hard coded to black)
- background_color - sets color of subtitle background box
- background_transparency - sets transparency of subtitle background box

I have replaced previous color "subtitles.blackWhite" with separate "subtitles.white" and "subtitles.black" colors - the name no longer made sense. Rest of the colors were reused.
I have also included transparency "subtitles.0%" (0%, 25%, 50%, 75% and 100%)
Not sure about proper translations/mapping of settings text - let me know if more needs to be done.


The change to "color" settings is a breaking change. It will fallback to MPV default (white text with black border) until users set their new preferences.
However I think it is worth it. It would allow more customization in the future.

It is a start to fixing https://github.com/jellyfin/jellyfin-media-player/issues/284 The feature parity is not 100%. If it looks good I can add more features in the future.