### PR TITLE
Fix icon for Wayland (#440 #462)

### DIFF
--- a/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
+++ b/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
@@ -6,7 +6,7 @@ Exec=jellyfinmediaplayer
 Icon=com.github.iwalton3.jellyfin-media-player
 Terminal=false
 Type=Application
-StartupWMClass=jellyfinmediaplayer
+StartupWMClass=com.github.iwalton3.jellyfin-media-player
 Categories=AudioVideo;Video;Player;TV;
 
 Actions=DesktopF;DesktopW;TVF;TVW

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,6 +178,8 @@ int main(int argc, char *argv[])
 #if defined(Q_OS_LINUX)
   	// Set window icon on Linux using system icon theme
   	app.setWindowIcon(QIcon::fromTheme("com.github.iwalton3.jellyfin-media-player", QIcon(":/images/icon.png")));
+    // Set app id for Wayland compositor window icon
+    app.setDesktopFileName("com.github.iwalton3.jellyfin-media-player");
 #endif
 
 #if defined(Q_OS_MAC) && defined(NDEBUG)


### PR DESCRIPTION
Same issue was resolved in another app https://github.com/OpenShot/openshot-qt/issues/1112

Solution to the taskbar icon, changed the value in the _.desktop_ file to use the proper id below section [Desktop Entry]
`StartupWMClass=com.github.iwalton3.jellyfin-media-player`

Solution to the icon of a Wayland application window is to set the correct XDG toplevel **app_id**.
Added a single line to _main.cpp_ with setDesktopFileName() 
![Screenshot_20231031_051259](https://github.com/jellyfin/jellyfin-media-player/assets/130854052/3f009d05-e403-40aa-b697-304a56d97b9e)
(originally this was "org.jellyfin.<application_name>", generated by Qt using setOrganizationDomain() and setApplicationName() values).

Result
![Screenshot_20231031_051756](https://github.com/jellyfin/jellyfin-media-player/assets/130854052/d0476b97-9d6d-4260-a461-03d282500345)

