### PR TITLE
Fix build on Qt 6.5+

### DIFF
--- a/src/input/InputComponent.cpp
+++ b/src/input/InputComponent.cpp
@@ -132,7 +132,11 @@ void InputComponent::handleAction(const QString& action)
         else
         {
           qDebug() << "Invoking slot" << qPrintable(recvSlot->m_slot.data());
-          QGenericArgument arg0 = QGenericArgument();
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+          QMetaMethodArgument arg0;
+#else
+          QGenericArgument arg0;
+#endif
 
           if (recvSlot->m_hasArguments)
             arg0 = Q_ARG(const QString&, hostArguments);


### PR DESCRIPTION
The Q_ARG has a different return value in  [Qt 6.5+](https://doc.qt.io/qt-6.5/qmetaobject.html#Q_ARG) than in [Qt 6.4](https://doc.qt.io/qt-6.4/qmetaobject.html#Q_ARG).

More info about the build error I got: https://github.com/jellyfin/jellyfin-media-player/pull/463#discussion_r1438864489