### PR TITLE
feat: add Apple silicon build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,26 +11,22 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
-    - name: Install Qt 5.15.2
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: "5.15.2"
-        modules: "qtwebengine"
-        setup-python: 'false'
     - name: Install dependencies
       run: |
         brew update
-        brew install ninja mpv || true
+        brew install ninja mpv qt@5 || true
     - name: Release build
       run: |
         ./download_webclient.sh
         sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         cd build
-        cmake -GNinja -DQTROOT=$Qt5_DIR -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=output ..
+        cmake -GNinja -DQTROOT=/usr/local/opt/qt@5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=output ..
         ninja install
     - name: Fix library paths and create dmg
       run: |
         python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
+        python3 ./scripts/fix-webengine.py ./build/output/Jellyfin\ Media\ Player.app
+        codesign --force --deep -s - ./build/output/Jellyfin\ Media\ Player.app/
         brew install create-dmg
         create-dmg --volname "Jellyfin Media Player" --no-internet-enable "JellyfinMediaPlayer.dmg" "./build/output/Jellyfin Media Player.app"
     - name: Archive production artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Qt 5.15.2
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       with:
         version: "5.15.2"
         modules: "qtwebengine"
@@ -24,12 +24,12 @@ jobs:
     - name: Release build
       run: |
         ./download_webclient.sh
+        sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         cd build
         cmake -GNinja -DQTROOT=$Qt5_DIR -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=output ..
         ninja install
     - name: Fix library paths and create dmg
       run: |
-        sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
         brew install create-dmg
         create-dmg --volname "Jellyfin Media Player" --no-internet-enable "JellyfinMediaPlayer.dmg" "./build/output/Jellyfin Media Player.app"
@@ -50,12 +50,12 @@ jobs:
     - name: Release build
       run: |
         ./download_webclient.sh
+        sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         cd build
         cmake -GNinja -DQTROOT=/opt/homebrew/opt/qt@5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=output ..
         ninja install
     - name: Fix library paths and create dmg
       run: |
-        sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
         python3 ./scripts/fix-webengine.py ./build/output/Jellyfin\ Media\ Player.app
         codesign --force --deep -s - ./build/output/Jellyfin\ Media\ Player.app/
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Qt 5.15.2
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       with:
         version: "5.15.2"
         arch: "win64_msvc2019_64"
@@ -118,7 +118,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Qt 5.15.2
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       with:
         version: "5.15.2"
         arch: "win32_msvc2019"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
     - name: Fix library paths and create dmg
       run: |
         python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
+        python3 ./scripts/fix-webengine.py ./build/output/Jellyfin\ Media\ Player.app
+        codesign --force --deep -s - ./build/output/Jellyfin\ Media\ Player.app/
         brew install create-dmg
         create-dmg --volname "Jellyfin Media Player" --no-internet-enable "JellyfinMediaPlayer.dmg" "./build/output/Jellyfin Media Player.app"
     - name: Archive production artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Archive production artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: macos
+        name: macos-arm64
         path: ${{ github.workspace }}/JellyfinMediaPlayer.dmg
 
   build-win64:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
       - test
 jobs:
   build-mac:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
     - name: Install Qt 5.15.2
@@ -29,6 +29,7 @@ jobs:
         ninja install
     - name: Fix library paths and create dmg
       run: |
+        sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
         brew install create-dmg
         create-dmg --volname "Jellyfin Media Player" --no-internet-enable "JellyfinMediaPlayer.dmg" "./build/output/Jellyfin Media Player.app"
@@ -54,6 +55,7 @@ jobs:
         ninja install
     - name: Fix library paths and create dmg
       run: |
+        sed -i '' 's/<body>/<body style="overscroll-behavior: none;">/' ./build/dist/index.html
         python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
         python3 ./scripts/fix-webengine.py ./build/output/Jellyfin\ Media\ Player.app
         codesign --force --deep -s - ./build/output/Jellyfin\ Media\ Player.app/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,31 @@ jobs:
         name: macos
         path: ${{ github.workspace }}/JellyfinMediaPlayer.dmg
 
+  build-macarm64:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install ninja mpv qt@5 || true
+    - name: Release build
+      run: |
+        ./download_webclient.sh
+        cd build
+        cmake -GNinja -DQTROOT=/opt/homebrew/opt/qt@5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=output ..
+        ninja install
+    - name: Fix library paths and create dmg
+      run: |
+        python3 ./scripts/fix-install-names.py ./build/output/Jellyfin\ Media\ Player.app
+        brew install create-dmg
+        create-dmg --volname "Jellyfin Media Player" --no-internet-enable "JellyfinMediaPlayer.dmg" "./build/output/Jellyfin Media Player.app"
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos
+        path: ${{ github.workspace }}/JellyfinMediaPlayer.dmg
+
   build-win64:
     runs-on: windows-latest
     steps:

--- a/scripts/fix-webengine.py
+++ b/scripts/fix-webengine.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+import os
+import argparse
+from collections import deque
+import subprocess
+import shutil
+
+def main(argv=tuple(sys.argv[1:])):
+  arg_parser = argparse.ArgumentParser(description='Fix third party library paths in .app bundles.')
+  arg_parser.add_argument('bundle', metavar='BUNDLE', type=str, nargs=1)
+  arguments = arg_parser.parse_args(argv)
+
+  bundle_path = Path(arguments.bundle[0])
+  print(bundle_path)
+  webengine_path = bundle_path / 'Contents' / 'Frameworks' / 'QtWebEngineCore.framework' / 'Helpers' / 'QtWebEngineProcess.app'
+  link_path = webengine_path / 'Contents' / 'Frameworks'
+  bin_to_fix = webengine_path / 'Contents' / 'MacOS' / 'QtWebEngineProcess'
+
+  os.symlink('../../../../../../../Frameworks', link_path)
+
+  result = subprocess.check_output(['otool', '-L', str(bin_to_fix.resolve())],stderr=subprocess.STDOUT).decode('utf-8')
+  for dependency in result.splitlines():
+    dependency = dependency.strip().lstrip()
+    if dependency.startswith('/opt/homebrew'):
+      # cut off trailing compatibility string
+      dependency_str = dependency.split(' (compatibility')[0].strip()
+      dependency_framework_str = dependency_str.split('/lib')[1].strip()
+      dependency_framework = Path(dependency_framework_str)
+      target = f'@executable_path/../Frameworks{dependency_framework_str}'
+      subprocess.run(['install_name_tool', '-id', target, bin_to_fix])
+      subprocess.run(['install_name_tool', '-change', dependency_str, target, bin_to_fix])
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This modified the build script to make it build with homebrew's qt5

GitHub's macOS 14 runner is Apple Silicon exclusive, so use that to build the image.

If the artifact is directly downloaded without code signing, the user will have to code sign it. An adhoc sign would be enough:

```
codesign --force --deep -s - Jellyfin\ Media\ Player.app/
```

Fixes #99