### PR TITLE
Fix Intro Skipper

### DIFF
--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -193,6 +193,14 @@ class skipIntroPlugin {
                     const onPlaybackStop = () => {
                         events.off(player, 'timeupdate', onTimeUpdate);
                         events.off(player, 'playbackstop', onPlaybackStop);
+
+                        // Reset skipIntro styles on playbackstop
+                        const skipIntro = document.querySelector(".skipIntro");
+                        if (skipIntro) {
+                            skipIntro.style.display = 'none';
+                            skipIntro.style.opacity = '0';
+                            skipIntro.classList.add("hide");
+                        }
                     };
                     events.on(player, 'playbackstop', onPlaybackStop);
                 }

--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -180,10 +180,10 @@ class skipIntroPlugin {
                         if (!skipIntro.classList.contains("hide")) return;
 
                         skipIntro.classList.remove("hide");
-                        skipIntro.style.display = 'block';
                         requestAnimationFrame(() => {
                             requestAnimationFrame(() => {
                                 skipIntro.style.opacity = '1';
+                                skipIntro.style.display = 'block';
                             });
                         });
                     };

--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -180,6 +180,7 @@ class skipIntroPlugin {
                         if (!skipIntro.classList.contains("hide")) return;
 
                         skipIntro.classList.remove("hide");
+                        skipIntro.style.display = 'block';
                         requestAnimationFrame(() => {
                             requestAnimationFrame(() => {
                                 skipIntro.style.opacity = '1';


### PR DESCRIPTION
The skip intro button remained hidden even when it should be visible. This was because the `display` property was still set to `none`. And this was only happening after exiting the video and returning or starting a new one. I don't know exactly what caused it.

Commit 1: If you don't click the button once, the `display` always returns `none` and `opacity 0`.
`<div class="skipIntro" style="style="display: none; opacity: 0;>`

Commit 2-3: Everything seems to be fixed now, whether you click the button or not, it still appears. Tested on 2 clients.

EDIT: https://github.com/jellyfin/jellyfin-media-player/issues/701 Apparently it doesn't work for everyone, I have no idea why. So it needs to be tested better, for me it works consistently, but maybe it has other problems. I'm not a dev, so someone more qualified should take a look (you can close this pull request if you prefer).
