### PR TITLE
debian: use shlibdeps substitution variable

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,13 +44,9 @@ Vcs-Browser: https://github.org/jellyfin/jellyfin-media-player
 
 Package: jellyfin-media-player
 Architecture: any
-Depends: libmpv1 | libmpv2,
-         libqt5webengine5,
-         libcec4 | libcec6,
+Depends: ${shlibs:Depends},
          qml-module-qtwebengine,
          qml-module-qtwebchannel,
-         qml-module-qtquick-controls,
-         libqt5x11extras5,
-         libqt5xml5
+         qml-module-qtquick-controls
 Description: Jellyfin is the Free Software Media System.
  This package provides the Jellyfin desktop media player.


### PR DESCRIPTION
Instead of manually listing dependencies (see <https://manpages.debian.org/deb-substvars.5#shlibs:>)


Before:

```console
$ apt depends jellyfin-media-player
jellyfin-media-player
 |Depends: <libmpv1>
  Depends: libmpv2
  Depends: libqt5webengine5
 |Depends: <libcec4>
  Depends: libcec6
  Depends: qml-module-qtwebengine
  Depends: qml-module-qtwebchannel
  Depends: qml-module-qtquick-controls
  Depends: libqt5x11extras5
  Depends: libqt5xml5
    libqt5xml5t64
```

After (on Debian Trixie):

```console
$ apt depends jellyfin-media-player
jellyfin-media-player
  Depends: libc6 (>= 2.34)
  Depends: libcec6 (>= 6.0.2)
  Depends: libgcc-s1 (>= 3.0)
  Depends: libmpv2 (>= 0.29)
  Depends: libqt5core5t64 (>= 5.15.1)
  Depends: libqt5dbus5t64 (>= 5.14.1)
 |Depends: libqt5gui5t64 (>= 5.8.0)
  Depends: libqt5gui5-gles (>= 5.8.0)
  Depends: libqt5network5t64 (>= 5.6.0~beta)
  Depends: libqt5qml5 (>= 5.1.0)
 |Depends: libqt5quick5 (>= 5.15.1)
  Depends: libqt5quick5-gles (>= 5.15.1)
  Depends: libqt5webchannel5 (>= 5.6.1)
  Depends: libqt5webengine5 (>= 5.7.1)
  Depends: libqt5widgets5t64 (>= 5.0.2)
  Depends: libqt5x11extras5 (>= 5.6.0)
  Depends: libqt5xml5t64 (>= 5.0.2)
  Depends: libsdl2-2.0-0 (>= 2.0.12)
  Depends: libstdc++6 (>= 13.1)
  Depends: libx11-6
  Depends: libxrandr2 (>= 2:1.2.99.3)
  Depends: qml-module-qtwebengine
  Depends: qml-module-qtwebchannel
  Depends: qml-module-qtquick-controls
```
