### PR TITLE
Fix Skip Intro Button Issue

### DIFF
--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -36,7 +36,7 @@ class skipIntroPlugin {
                 background-color:rgba(25, 25, 25, 0.66);
                 border: 1px solid;
                 border-radius: 0px;
-                display: inline-block;
+                display: inline-block !important;
                 cursor: pointer;
                 box-shadow: inset 0 0 0 0 #f9f9f9;
                 -webkit-transition: ease-out 0.4s;
@@ -163,9 +163,8 @@ class skipIntroPlugin {
                         currentPlayer = player;
                         switch (segment["SegmentType"]) {
                             case "None":
-                                if (skipIntro.style.opacity === '0') return;
+                                if (skipIntro.classList.contains("hide")) return;
 
-                                skipIntro.style.opacity = '0';
                                 skipIntro.addEventListener("transitionend", () => {
                                     skipIntro.classList.add("hide");
                                 }, { once: true });
@@ -180,11 +179,6 @@ class skipIntroPlugin {
                         if (!skipIntro.classList.contains("hide")) return;
 
                         skipIntro.classList.remove("hide");
-                        requestAnimationFrame(() => {
-                            requestAnimationFrame(() => {
-                                skipIntro.style.opacity = '1';
-                            });
-                        });
                     };
 
                     events.on(player, 'timeupdate', onTimeUpdate);

--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -9,7 +9,7 @@ class skipIntroPlugin {
         this.type = 'input';
         this.id = 'skipIntroPlugin';
 
-        (async() => {
+        (async () => {
             await window.initCompleted;
             const enabled = window.jmpInfo.settings.plugins.skipintro;
 
@@ -36,7 +36,7 @@ class skipIntroPlugin {
                 background-color:rgba(25, 25, 25, 0.66);
                 border: 1px solid;
                 border-radius: 0px;
-                display: inline-block;
+                display: inline-block !important;
                 cursor: pointer;
                 box-shadow: inset 0 0 0 0 #f9f9f9;
                 -webkit-transition: ease-out 0.4s;

--- a/native/skipIntroPlugin.js
+++ b/native/skipIntroPlugin.js
@@ -36,7 +36,7 @@ class skipIntroPlugin {
                 background-color:rgba(25, 25, 25, 0.66);
                 border: 1px solid;
                 border-radius: 0px;
-                display: inline-block !important;
+                display: inline-block;
                 cursor: pointer;
                 box-shadow: inset 0 0 0 0 #f9f9f9;
                 -webkit-transition: ease-out 0.4s;
@@ -163,8 +163,9 @@ class skipIntroPlugin {
                         currentPlayer = player;
                         switch (segment["SegmentType"]) {
                             case "None":
-                                if (skipIntro.classList.contains("hide")) return;
+                                if (skipIntro.style.opacity === '0') return;
 
+                                skipIntro.style.opacity = '0';
                                 skipIntro.addEventListener("transitionend", () => {
                                     skipIntro.classList.add("hide");
                                 }, { once: true });
@@ -179,6 +180,11 @@ class skipIntroPlugin {
                         if (!skipIntro.classList.contains("hide")) return;
 
                         skipIntro.classList.remove("hide");
+                        requestAnimationFrame(() => {
+                            requestAnimationFrame(() => {
+                                skipIntro.style.opacity = '1';
+                            });
+                        });
                     };
 
                     events.on(player, 'timeupdate', onTimeUpdate);


### PR DESCRIPTION
Resolves issue #701.

The skip intro button works fine on the first stream after the Jellyfin Client is launched. However, subsequent streams doesn’t show the `Skip Intro` or `Skip Credit` button as a `display: none` property gets added in later streams, which prevents it from showing up. ~~This PR cleans up all instances of the `opacity` css property as the button already uses the `.hide` class name, like many other Jellyfin Web elements to show and hide it.~~