### PR TITLE
Fix removing trailing slash making JMP unable to connect to some servers

### DIFF
--- a/native/find-webclient.js
+++ b/native/find-webclient.js
@@ -5,9 +5,8 @@ async function tryConnect(server) {
         if (!server.startsWith("http")) {
             server = "http://" + server;
         }
-        server = server.replace(/\/+$/, "");
-
-        const url = server + "/System/Info/Public";
+        serverBaseURL = server.replace(/\/+$/, "");
+        const url = serverBaseURL + "/System/Info/Public";
         const response = await fetch(url);
         if (response.ok && (await response.json()).Id) {
             const htmlResponse = await fetch(server);


### PR DESCRIPTION
Resolves issue https://github.com/jellyfin/jellyfin-media-player/issues/754.

My proposal is to leave the trailing slash for connecting to the Jellyfin server (l.12) and strip it out only for accessing metadata at "/System/Info/Public"