### PR TITLE
Don't junk the server URL if subsequent connection failed

### DIFF
--- a/native/find-webclient.js
+++ b/native/find-webclient.js
@@ -78,6 +78,9 @@ document.getElementById('connect-fail-button').addEventListener('click', () => {
 // load the server if we have one
 (async() => {
     const savedServer = window.jmpInfo.settings.main.userWebClient;
+    if (savedServer) {
+        document.getElementById('address').value = savedServer;
+    }
 
     if (!savedServer || !(await tryConnect(savedServer))) {
         document.getElementById('splash').style.display = 'none';


### PR DESCRIPTION
So currently a failure to connect to a previously saved server will present an empty server connect page again.

But this sucks, because either the server or user's internet connection might be down, and we know the server should be okay since it worked before. So this fills out the address text input with the currently saved server, this way the user can easily retry the connection without being frustrated that the server URL was junked and they gotta pull it out of memory and re-type to reconnect.

Now the way I understand it, it was never junked from the local storage to begin with, so technically they'd be able to reconnect by restarting the app too? But nobody would ever guess that if they see empty connection form, they'd assume all was reset.

Also it is my sincere hope that in such a situation local storage in terms of login data won't be junked either hopefully, but even if it does, this PR is still going to make it all a bit less of PITA for users