### PR TITLE
Use 'no-cache' when fetching server or update data

### DIFF
--- a/native/find-webclient.js
+++ b/native/find-webclient.js
@@ -7,9 +7,9 @@ async function tryConnect(server) {
         }
         serverBaseURL = server.replace(/\/+$/, "");
         const url = serverBaseURL + "/System/Info/Public";
-        const response = await fetch(url);
+        const response = await fetch(url, { cache: 'no-cache' });
         if (response.ok && (await response.json()).Id) {
-            const htmlResponse = await fetch(server);
+            const htmlResponse = await fetch(server, { cache: 'no-cache' });
             if (!htmlResponse.ok) {
                 throw new Error("Status not ok");
             }

--- a/native/jmpUpdatePlugin.js
+++ b/native/jmpUpdatePlugin.js
@@ -12,7 +12,7 @@ class jmpUpdatePlugin {
                     // Windows (and possibly macOS) don't ship with SSL in QT......
                     // So we get to do a full request to GitHub here :(
                     const checkUrl = "https://github.com/jellyfin/jellyfin-media-player/releases/latest";
-                    url = (await fetch(checkUrl)).url;
+                    url = (await fetch(checkUrl, { cache: 'no-cache' })).url;
                 }
 
                 const urlSegments = url.split("/");

--- a/native/jmpUpdatePlugin.js
+++ b/native/jmpUpdatePlugin.js
@@ -12,7 +12,7 @@ class jmpUpdatePlugin {
                     // Windows (and possibly macOS) don't ship with SSL in QT......
                     // So we get to do a full request to GitHub here :(
                     const checkUrl = "https://github.com/jellyfin/jellyfin-media-player/releases/latest";
-                    url = (await fetch(checkUrl, { cache: 'no-cache' })).url;
+                    url = (await fetch(checkUrl)).url;
                 }
 
                 const urlSegments = url.split("/");


### PR DESCRIPTION
Should fix #688. I've added a no cache attribute to everything that either uses the `/System/Info` api, or that only cares about the latest data anyway, as the requests are done once at the beginning of a session. I've looked and could only find the fetch requests already changed in the PR, if there are any more please let me know and I'll fix those as well.