### PR TITLE
Add required Fedora packages for building and running Jellyfin Media Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ rm -rf ~/jmp/
 
 Install dependencies:
 ```bash
-sudo dnf install autoconf automake libtool freetype-devel libXrandr-devel libvdpau-devel libva-devel  mesa-libGL-devel libdrm-devel libX11-devel  mesa-libEGL-devel yasm  alsa-lib pulseaudio-libs-devel zlib-devel fribidi-devel git gnutls-devel mesa-libGLU-devel  SDL2-devel cmake wget python g++  qt-devel libcec-devel qt5-qtbase-devel curl unzip qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtx11extras-devel mpv.x86_64 qwt-qt5-devel.x86_64 qt5-qtbase.x86_64 meson.noarch ninja-build.x86_64 qt5-qtbase-private-devel mpv-libs.x86_64
+sudo dnf install autoconf automake libtool freetype-devel libXrandr-devel libvdpau-devel libva-devel  mesa-libGL-devel libdrm-devel libX11-devel  mesa-libEGL-devel yasm  alsa-lib pulseaudio-libs-devel zlib-devel fribidi-devel git gnutls-devel mesa-libGLU-devel  SDL2-devel cmake wget python g++  qt-devel libcec-devel qt5-qtbase-devel curl unzip qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtx11extras-devel mpv.x86_64 qwt-qt5-devel.x86_64 qt5-qtbase.x86_64 meson.noarch ninja-build.x86_64 qt5-qtbase-private-devel mpv-libs.x86_64 mpv-devel qt5-qtquickcontrols qt5-qtquickcontrols2
 ```
 
 Build commands for Fedora:


### PR DESCRIPTION
While building and running **Jellyfin Media Player** from source on **Fedora** 41, I encountered both build-time and runtime issues due to missing system packages. This PR proposes adding a list of required `dnf` packages to the build documentation to prevent these errors.

---

### What Happened

#### 1. Missing `mpv-devel`

The build failed with the following CMake error:


Resolved by installing:

sudo dnf install mpv-devel
Crash on Launch: Missing QML Module
After a successful build, the application crashed on launch with this fatal error:

Unhandled FatalException: Failed to parse application engine script.
qrc:/ui/webview.qml:6:1: module "QtQuick.Controls" is not installed
Resolved by installing:

sudo dnf install qt5-qtquickcontrols qt5-qtquickcontrols2



###  My Proposed Change
Update the Fedora build instructions to include the following required packages:

sudo dnf install mpv-devel qt5-qtquickcontrols qt5-qtquickcontrols2


This ensures that both the MPV backend and QML UI components are available so Jellyfin Media Player can build and launch correctly on Fedora systems.

Let me know if you have any questions.

Thanks,